### PR TITLE
Use new API container image in kubernetes

### DIFF
--- a/terraform/api/main.tf
+++ b/terraform/api/main.tf
@@ -65,8 +65,12 @@ resource "kubernetes_deployment" "api" {
       }
 
       spec {
+        image_pull_secrets {
+          name = "regcred"
+        }
+
         container {
-          image = "registry.digitalocean.com/foreign-language-reader-api/api:latest"
+          image = "lkjaero/foreign-language-reader-api:latest"
           name  = "api"
 
           port {

--- a/terraform/nginx_ingress/main.tf
+++ b/terraform/nginx_ingress/main.tf
@@ -18,7 +18,7 @@ resource "helm_release" "nginx_ingress" {
 # Use this to get the load balancer external IP for DNS configuration
 data "kubernetes_service" "nginx" {
   metadata {
-    name = "nginx-ingress-nginx-ingress"
+    name      = "nginx-ingress-nginx-ingress"
     namespace = var.namespace
   }
   depends_on = [helm_release.nginx_ingress]

--- a/terraform/nginx_ingress/main.tf
+++ b/terraform/nginx_ingress/main.tf
@@ -19,6 +19,7 @@ resource "helm_release" "nginx_ingress" {
 data "kubernetes_service" "nginx" {
   metadata {
     name = "nginx-ingress-nginx-ingress"
+    namespace = var.namespace
   }
   depends_on = [helm_release.nginx_ingress]
 }


### PR DESCRIPTION
We've changed the location, let's use the new image