### PR TITLE
Elasticsearch setup

### DIFF
--- a/kubernetes/elasticsearch/content.yml
+++ b/kubernetes/elasticsearch/content.yml
@@ -2,6 +2,7 @@ apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
 metadata:
   name: content
+  namespace: content
 spec:
   version: 7.10.1
   nodeSets:

--- a/kubernetes/elasticsearch/logging.yml
+++ b/kubernetes/elasticsearch/logging.yml
@@ -4,7 +4,7 @@ metadata:
   name: logs
   namespace: logging
 spec:
-  version: 7.6.2
+  version: 7.10.1
   nodeSets:
   - name: logs
     count: 1

--- a/kubernetes/elasticsearch/production.yml
+++ b/kubernetes/elasticsearch/production.yml
@@ -1,11 +1,11 @@
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
 metadata:
-  name: language-content
+  name: content
 spec:
-  version: 7.6.2
+  version: 7.10.1
   nodeSets:
-  - name: production
+  - name: content
     count: 1
     config:
       node.master: true

--- a/kubernetes/kibana/content.yml
+++ b/kubernetes/kibana/content.yml
@@ -1,0 +1,10 @@
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: content
+  namespace: content
+spec:
+  version: 7.10.1
+  count: 1
+  elasticsearchRef:
+    name: content

--- a/kubernetes/kibana/logs.yml
+++ b/kubernetes/kibana/logs.yml
@@ -4,7 +4,7 @@ metadata:
   name: logs
   namespace: logging
 spec:
-  version: 7.6.2
+  version: 7.10.1
   count: 1
   elasticsearchRef:
     name: logs

--- a/terraform/api/main.tf
+++ b/terraform/api/main.tf
@@ -107,6 +107,21 @@ resource "kubernetes_deployment" "api" {
             }
           }
 
+          env {
+            name = "ELASTICSEARCH_PASSWORD"
+            value_from {
+              secret_key_ref {
+                name = "elasticsearch_credentials"
+                key  = "password"
+              }
+            }
+          }
+
+          env {
+            name  = "ENVIRONMENT"
+            value = var.env
+          }
+
           resources {
             limits {
               memory = "500Mi"
@@ -204,5 +219,21 @@ resource "kubernetes_secret" "application-secret" {
 
   data = {
     application_secret = random_password.application_secret.result
+  }
+}
+
+resource "random_password" "elasticsearch_password" {
+  length  = 64
+  special = true
+}
+
+resource "kubernetes_secret" "elasticsearch-credentials" {
+  metadata {
+    name      = "elasticsearch_credentials"
+    namespace = var.env
+  }
+
+  data = {
+    password = random_password.elasticsearch_password.result
   }
 }

--- a/terraform/api/main.tf
+++ b/terraform/api/main.tf
@@ -111,7 +111,7 @@ resource "kubernetes_deployment" "api" {
             name = "ELASTICSEARCH_PASSWORD"
             value_from {
               secret_key_ref {
-                name = "elasticsearch_credentials"
+                name = "elasticsearch-credentials"
                 key  = "password"
               }
             }
@@ -227,9 +227,9 @@ resource "random_password" "elasticsearch_password" {
   special = true
 }
 
-resource "kubernetes_secret" "elasticsearch-credentials" {
+resource "kubernetes_secret" "elasticsearch_credentials" {
   metadata {
-    name      = "elasticsearch_credentials"
+    name      = "elasticsearch-credentials"
     namespace = var.env
   }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -117,9 +117,9 @@ module "content" {
 }
 
 # Contains logging and monitoring configuration
-# module "monitoring" {
-#   source = "./monitoring"
-# }
+module "monitoring" {
+  source = "./monitoring"
+}
 
 # Ingress
 # Handles traffic going in to the cluster

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -125,16 +125,6 @@ module "monitoring" {
 # Handles traffic going in to the cluster
 # Proxies everything through a load balancer and nginx
 
-# module "nginx_ingress_logging" {
-#   source          = "./nginx_ingress"
-#   domain          = digitalocean_domain.main.name
-#   subdomains      = ["kibana"]
-#   private_key_pem = acme_certificate.certificate.private_key_pem
-#   certificate_pem = acme_certificate.certificate.certificate_pem
-#   issuer_pem      = acme_certificate.certificate.issuer_pem
-#   namespace       = "default"
-# }
-
 module "nginx_ingress_prod" {
   source          = "./nginx_ingress"
   domain          = digitalocean_domain.main.name
@@ -144,34 +134,6 @@ module "nginx_ingress_prod" {
   issuer_pem      = acme_certificate.certificate.issuer_pem
   namespace       = "prod"
 }
-
-# resource "kubernetes_ingress" "foreign_language_reader_ingress" {
-#   metadata {
-#     name = "foreign-language-reader-ingress"
-#     annotations = {
-#       "kubernetes.io/ingress.class"             = "nginx"
-#       "nginx.ingress.kubernetes.io/enable-cors" = "true"
-#     }
-#   }
-
-#   spec {
-#     tls {
-#       secret_name = "nginx-certificate"
-#     }
-
-#     rule {
-#       host = "kibana.foreignlanguagereader.com"
-#       http {
-#         path {
-#           backend {
-#             service_name = "kibana-kibana"
-#             service_port = 5601
-#           }
-#         }
-#       }
-#     }
-#   }
-# }
 
 resource "kubernetes_ingress" "prod_ingress" {
   metadata {

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -1,9 +1,10 @@
 # Required for horizontal pod autoscaling to work
+# TODO update this location when a new home for this chart is found.
 resource "helm_release" "metrics_server" {
   name       = "metrics-server"
   repository = "https://kubernetes-charts.storage.googleapis.com"
   chart      = "metrics-server"
-  version    = "2.10.1"
+  version    = "2.11.4"
 }
 
 # Logging configuration
@@ -27,9 +28,9 @@ resource "random_password" "fluent_elasticsearch_password" {
 
 resource "helm_release" "fluentd_elasticsearch" {
   name       = "fluentd"
-  repository = "https://kiwigrid.github.io"
+  repository = "https://kokuwaio.github.io/helm-charts"
   chart      = "fluentd-elasticsearch"
-  version    = "6.2.2"
+  version    = "11.6.2"
   namespace  = "logging"
 
   values = [file("${path.module}/fluentd.yml")]


### PR DESCRIPTION
- Elasticsearch and kibana pair for logging, with fluentd feeding logs from all pods.
- Elasticsearch and kibana pair for content, shared between all environments.
- Elasticsearch credentials for api server.
- Upgrade metrics-server version.