### PR TITLE
Connect fluentd to elasticsearch

### DIFF
--- a/terraform/monitoring/fluentd.yml
+++ b/terraform/monitoring/fluentd.yml
@@ -2,6 +2,7 @@ elasticsearch:
   auth:
     enabled: true
     user: fluentd
-  host: logs-es-http.logging.svc.cluster.local
+  hosts: 
+    - logs-es-http.logging.svc.cluster.local
   scheme: https
   sslVerify: false

--- a/terraform/monitoring/main.tf
+++ b/terraform/monitoring/main.tf
@@ -1,11 +1,11 @@
 # Required for horizontal pod autoscaling to work
 # TODO update this location when a new home for this chart is found.
-resource "helm_release" "metrics_server" {
-  name       = "metrics-server"
-  repository = "https://kubernetes-charts.storage.googleapis.com"
-  chart      = "metrics-server"
-  version    = "2.11.4"
-}
+# resource "helm_release" "metrics_server" {
+#   name       = "metrics-server"
+#   repository = "https://kubernetes-charts.storage.googleapis.com"
+#   chart      = "metrics-server"
+#   version    = "2.11.4"
+# }
 
 # Logging configuration
 # Every node has a log collection agent that posts logs to elasticsearch


### PR DESCRIPTION
- Correctly specify the elasticsearch hostname
- Remove deprecated and unresolvable metrics-server helm chart.