### PR TITLE
Elasticsearch backs up to S3

### DIFF
--- a/terraform/elasticsearch/elasticsearch.yml
+++ b/terraform/elasticsearch/elasticsearch.yml
@@ -42,3 +42,5 @@ spec:
           requests:
             storage: 100Gi
         storageClassName: do-block-storage
+  secureSettings:
+  - secretName: elasticsearch-s3-creds

--- a/terraform/elasticsearch/main.tf
+++ b/terraform/elasticsearch/main.tf
@@ -132,3 +132,13 @@ resource "kubernetes_secret" "elasticsearch_aws_credentials" {
     "s3.client.default.secret_key" = aws_iam_access_key.elasticsearch.secret
   }
 }
+
+# Backup configuration
+
+resource elasticsearch_snapshot_repository "backups" {
+  name     = "S3-backup"
+  type     = "s3"
+  settings = {
+    "bucket" = aws_s3_bucket.backup.id
+  }
+}

--- a/terraform/elasticsearch/main.tf
+++ b/terraform/elasticsearch/main.tf
@@ -103,7 +103,12 @@ resource "aws_iam_user" "elasticsearch" {
 
 data "aws_iam_policy_document" "elasticsearch_backup" {
   statement {
-    actions   = ["s3:PutObject", "s3:GetObjectAcl", "s3:GetObject", "s3:ListBucketMultipartUploads", "s3:AbortMultipartUpload", "s3:ListBucket", "s3:DeleteObject", "s3:GetBucketLocation", "s3:PutObjectAcl", "s3:ListMultipartUploadParts"]
+    actions   = ["s3:ListBucket", "s3:GetBucketLocation", "s3:ListBucketMultipartUploads", "s3:ListBucketVersions"]
+    effect    = "Allow"
+    resources = [aws_s3_bucket.backup.arn]
+  }
+  statement {
+    actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:AbortMultipartUpload", "s3:ListMultipartUploadParts"]
     effect    = "Allow"
     resources = ["${aws_s3_bucket.backup.arn}/*"]
   }

--- a/terraform/elasticsearch/main.tf
+++ b/terraform/elasticsearch/main.tf
@@ -121,4 +121,14 @@ resource "aws_iam_policy_attachment" "elasticsearch_backup" {
   users      = [aws_iam_user.elasticsearch.name]
   policy_arn = aws_iam_policy.elasticsearch_backup.arn
 }
+
+resource "kubernetes_secret" "elasticsearch_aws_credentials" {
+  metadata {
+    name = "elasticsearch-s3-creds"
+  }
+
+  data = {
+    "s3.client.default.access_key" = aws_iam_access_key.elasticsearch.id
+    "s3.client.default.secret_key" = aws_iam_access_key.elasticsearch.secret
+  }
 }

--- a/terraform/elasticsearch/main.tf
+++ b/terraform/elasticsearch/main.tf
@@ -186,9 +186,9 @@ resource "kubernetes_secret" "elasticsearch_aws_credentials" {
 
 # Backup configuration
 
-resource elasticsearch_snapshot_repository "backups" {
-  name     = "S3-backup"
-  type     = "s3"
+resource "elasticsearch_snapshot_repository" "backups" {
+  name = "S3-backup"
+  type = "s3"
   settings = {
     "bucket" = aws_s3_bucket.backup.id
   }


### PR DESCRIPTION
- S3 bucket and roles for backup up S3.
- Credentials passed to S3 backup plugin.
- Bucket registered as a snapshot repository.