### PR TITLE
Elasticsearch backup policy

### DIFF
--- a/terraform/elasticsearch/elasticsearch.yml
+++ b/terraform/elasticsearch/elasticsearch.yml
@@ -8,6 +8,8 @@ spec:
   auth:
     roles:
     - secretName: elasticsearch-roles
+  secureSettings:
+  - secretName: elasticsearch-s3-creds
   http:
     tls:
       certificate:
@@ -42,5 +44,3 @@ spec:
           requests:
             storage: 100Gi
         storageClassName: do-block-storage
-  secureSettings:
-  - secretName: elasticsearch-s3-creds

--- a/terraform/elasticsearch/main.tf
+++ b/terraform/elasticsearch/main.tf
@@ -193,3 +193,20 @@ resource "elasticsearch_snapshot_repository" "backups" {
     "bucket" = aws_s3_bucket.backup.id
   }
 }
+
+resource elasticsearch_snapshot_lifecycle_policy "daily_backup" {
+  name            = "daily-snapshots"
+  snapshot_name = "backup"
+  schedule         = "0 30 1 * * ?"
+  repository    = elasticsearch_snapshot_repository.backups.name
+  configs        = <<EOF
+{
+    "partial": true,
+}
+EOF
+  retention       = <<EOF
+{
+    "expire_after": "120d"
+}
+EOF
+}

--- a/terraform/elasticsearch/main.tf
+++ b/terraform/elasticsearch/main.tf
@@ -194,17 +194,17 @@ resource "elasticsearch_snapshot_repository" "backups" {
   }
 }
 
-resource elasticsearch_snapshot_lifecycle_policy "daily_backup" {
-  name            = "daily-snapshots"
+resource "elasticsearch_snapshot_lifecycle_policy" "daily_backup" {
+  name          = "daily-snapshots"
   snapshot_name = "backup"
-  schedule         = "0 30 1 * * ?"
+  schedule      = "0 30 1 * * ?"
   repository    = elasticsearch_snapshot_repository.backups.name
-  configs        = <<EOF
+  configs       = <<EOF
 {
     "partial": true,
 }
 EOF
-  retention       = <<EOF
+  retention     = <<EOF
 {
     "expire_after": "120d"
 }
@@ -212,8 +212,8 @@ EOF
 }
 
 # Automated log rollover
-resource elasticsearch_index_lifecycle_policy "rollover" {
-  name = "logging-rollover"
+resource "elasticsearch_index_lifecycle_policy" "rollover" {
+  name   = "logging-rollover"
   policy = <<EOF
 {
   "policy": {
@@ -243,9 +243,9 @@ EOF
   depends_on = [elasticsearch_snapshot_lifecycle_policy.daily_backup]
 }
 
-resource elasticsearch_index_template "fluentd" {
-  name         = "fluentd"
-  template     = <<EOF
+resource "elasticsearch_index_template" "fluentd" {
+  name     = "fluentd"
+  template = <<EOF
 {
   "index_patterns": [
     "logstash-*"


### PR DESCRIPTION
- Backup elasticsearch documents to S3
- Backups are retained for 120 days
- Log indexes are deleted after 30 days, but kept in backup for the full 120 days.