### PR TITLE
Spark can do everything for its bucket

### DIFF
--- a/terraform/content/main.tf
+++ b/terraform/content/main.tf
@@ -52,7 +52,7 @@ resource "aws_iam_policy_attachment" "spark_read" {
 
 data "aws_iam_policy_document" "spark_write" {
   statement {
-    actions   = ["s3:PutObject"]
+    actions   = ["*"]
     effect    = "Allow"
     resources = ["${aws_s3_bucket.content.arn}/*"]
   }


### PR DESCRIPTION
This is spark's bucket. No need to make permissions too fine grained.